### PR TITLE
Migrate to scalable tag bucket data structure

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -3,7 +3,8 @@ mod interface;
 #[macro_use]
 mod mac;
 mod constant;
-mod model;
+#[macro_use]
+pub mod model;
 mod storage;
 mod util;
 

--- a/db/src/mac/tx.rs
+++ b/db/src/mac/tx.rs
@@ -29,14 +29,14 @@ macro_rules! impl_global_transaction {
 			}
 
 			// Count number of items
-			async fn count(&mut self, cf: CF) -> Result<usize, Error> {
+			async fn count(&mut self, tags: TagBucket) -> Result<usize, Error> {
 				match self {
 					$(
 						#[cfg(feature = $feat)]
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.count(cf).await,
+						} => ds.count(tags).await,
 					)*
 				}
 			}
@@ -55,44 +55,27 @@ macro_rules! impl_global_transaction {
 			}
 
 			// Check if a key exists
-			async fn exi<K: Into<Key> + Send>(&self, cf: CF, key: K) -> Result<bool, Error> {
+			async fn exi<K: Into<Key> + Send>(&self, key: K, tags: TagBucket) -> Result<bool, Error> {
 				match self {
 					$(
 						#[cfg(feature = $feat)]
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.exi(cf, key).await,
+						} => ds.exi(key, tags).await,
 					)*
 				}
 			}
 
 			/// Fetch a key from the database
-			async fn get<K: Into<Key> + Send>(&self, cf: CF, key: K) -> Result<Option<Val>, Error> {
+			async fn get<K: Into<Key> + Send>(&self, key: K, tags: TagBucket) -> Result<Option<Val>, Error> {
 				match self {
 					$(
 						#[cfg(feature = $feat)]
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.get(cf, key).await,
-					)*
-				}
-			}
-
-			// OPTIONAL Fetch multiple keys from the database
-			async fn multi_get<K: Into<Key> + Send + AsRef<[u8]>>(
-				&self,
-				cf: CF,
-				keys: Vec<K>,
-			) -> Result<Vec<Option<Val>>, Error> {
-				match self {
-					$(
-						#[cfg(feature = $feat)]
-						Transaction {
-							inner: Inner::$x(ds),
-							..
-						} => ds.multi_get(cf, keys).await,
+						} => ds.get(key, tags).await,
 					)*
 				}
 			}
@@ -100,9 +83,9 @@ macro_rules! impl_global_transaction {
 			/// Insert or update a key in the database
 			async fn set<K: Into<Key> + Send, V: Into<Key> + Send>(
 				&mut self,
-				cf: CF,
 				key: K,
 				val: V,
+				tags: TagBucket
 			) -> Result<(), Error> {
 				match self {
 					$(
@@ -110,7 +93,7 @@ macro_rules! impl_global_transaction {
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.set(cf, key, val).await,
+						} => ds.set(key, val, tags).await,
 					)*
 				}
 			}
@@ -118,9 +101,9 @@ macro_rules! impl_global_transaction {
 			/// Insert a key if it doesn't exist in the database
 			async fn put<K: Into<Key> + Send, V: Into<Key> + Send>(
 				&mut self,
-				cf: CF,
 				key: K,
 				val: V,
+				tags: TagBucket
 			) -> Result<(), Error> {
 				match self {
 					$(
@@ -128,28 +111,28 @@ macro_rules! impl_global_transaction {
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.put(cf, key, val).await,
+						} => ds.put(key, val, tags).await,
 					)*
 				}
 			}
 
 			/// Delete a key
-			async fn del<K: Into<Key> + Send>(&mut self, cf: CF, key: K) -> Result<(), Error> {
+			async fn del<K: Into<Key> + Send>(&mut self, key: K, tags: TagBucket) -> Result<(), Error> {
 				match self {
 					$(
 						#[cfg(feature = $feat)]
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.del(cf, key ).await,
+						} => ds.del(key, tags).await,
 					)*
 				}
 			}
 
 			async fn prefix_iterate<P>(
 				&self,
-				cf: CF,
 				prefix: P,
+				tags: TagBucket
 			) -> Result<Vec<Result<(Val, Val), Error>>, Error>
 			where
 				P: Into<Key> + Send,
@@ -160,15 +143,15 @@ macro_rules! impl_global_transaction {
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.prefix_iterate(cf, prefix).await,
+						} => ds.prefix_iterate(prefix, tags).await,
 					)*
 				}
 			}
 
 			async fn suffix_iterate<S>(
 				&self,
-				cf: CF,
 				suffix: S,
+				tags: TagBucket,
 			) -> Result<Vec<Result<(Val, Val), Error>>, Error>
 			where
 				S: Into<Key> + Send,
@@ -179,18 +162,18 @@ macro_rules! impl_global_transaction {
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.suffix_iterate(cf, suffix).await,
+						} => ds.suffix_iterate(suffix, tags).await,
 					)*
 				}
 			}
 
-			async fn iterate(&self, cf: CF) -> Result<Vec<Result<(Val, Val), Error>>, Error> {
+			async fn iterate(&self, tags: TagBucket) -> Result<Vec<Result<(Val, Val), Error>>, Error> {
 				match self {
 					$(
 						Transaction {
 							inner: Inner::$x(ds),
 							..
-						} => ds.iterate(cf).await,
+						} => ds.iterate(tags).await,
 					)*
 				}
 			}

--- a/db/src/model/mod.rs
+++ b/db/src/model/mod.rs
@@ -1,6 +1,8 @@
 /// Model
 mod adapter;
+mod tag;
 mod tx;
 
 pub use adapter::*;
+pub use tag::*;
 pub use tx::*;

--- a/db/src/model/tag.rs
+++ b/db/src/model/tag.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+type TagKey = &'static str;
+type TagValue = String;
+type TagBucketInner = HashMap<TagKey, TagValue>;
+
+#[derive(Clone, Default)]
+pub struct TagBucket(TagBucketInner);
+
+#[macro_export]
+macro_rules! tag {
+	($($key: expr => $value: expr),*) => {{
+		#[allow(unused_mut)]
+  let mut map = std::collections::HashMap::default();
+  $(
+   map.insert($key, $value);
+  )*
+  $crate::TagBucket::new(map)
+ }};
+}
+
+impl TagBucket {
+	pub fn new(map: TagBucketInner) -> TagBucket {
+		TagBucket(map)
+	}
+
+	pub fn get(&self, key: TagKey) -> Option<TagValue> {
+		self.0.get(key).cloned()
+	}
+
+	pub fn unchecked_get(&self, key: TagKey) -> TagValue {
+		self.0.get(key).unwrap().clone()
+	}
+
+	pub fn get_bytes(&self, key: TagKey) -> Option<Vec<u8>> {
+		let wrapped_value = self.0.get(key).cloned();
+		if let Some(v) = wrapped_value {
+			return Some(v.as_bytes().to_vec());
+		}
+		None
+	}
+}

--- a/db/src/model/tx.rs
+++ b/db/src/model/tx.rs
@@ -5,6 +5,7 @@ use crate::{
 		KeyValuePair,
 	},
 	util::now,
+	TagBucket,
 };
 use async_trait::async_trait;
 use futures::lock::Mutex;
@@ -59,59 +60,51 @@ pub trait SimpleTransaction {
 	async fn cancel(&mut self) -> Result<(), Error>;
 
 	// Count number of items
-	async fn count(&mut self, cf: CF) -> Result<usize, Error>;
+	async fn count(&mut self, tags: TagBucket) -> Result<usize, Error>;
 
 	// Commit a transaction
 	async fn commit(&mut self) -> Result<(), Error>;
 
 	// Check if a key exists
-	async fn exi<K: Into<Key> + Send>(&self, cf: CF, key: K) -> Result<bool, Error>;
+	async fn exi<K: Into<Key> + Send>(&self, key: K, tags: TagBucket) -> Result<bool, Error>;
 
 	/// Fetch a key from the database
-	async fn get<K: Into<Key> + Send>(&self, cf: CF, key: K) -> Result<Option<Val>, Error>;
+	async fn get<K: Into<Key> + Send>(&self, key: K, tags: TagBucket)
+		-> Result<Option<Val>, Error>;
 
 	/// Insert or update a key in the database
 	async fn set<K: Into<Key> + Send, V: Into<Key> + Send>(
 		&mut self,
-		cf: CF,
 		key: K,
 		val: V,
+		tags: TagBucket,
 	) -> Result<(), Error>;
 
 	/// Insert a key if it doesn't exist in the database
 	async fn put<K: Into<Key> + Send, V: Into<Key> + Send>(
 		&mut self,
-		cf: CF,
 		key: K,
 		val: V,
+		tags: TagBucket,
 	) -> Result<(), Error>;
 
 	/// Delete a key
-	async fn del<K: Into<Key> + Send>(&mut self, cf: CF, key: K) -> Result<(), Error>;
-
-	// OPTIONAL Fetch multiple keys from the database
-	async fn multi_get<K: Into<Key> + Send + AsRef<[u8]>>(
-		&self,
-		_cf: CF,
-		_keys: Vec<K>,
-	) -> Result<Vec<Option<Val>>, Error> {
-		todo!();
-	}
+	async fn del<K: Into<Key> + Send>(&mut self, key: K, tags: TagBucket) -> Result<(), Error>;
 
 	// Iterate elements in key value store
-	async fn iterate(&self, cf: CF) -> Result<Vec<Result<KeyValuePair, Error>>, Error>;
+	async fn iterate(&self, tags: TagBucket) -> Result<Vec<Result<KeyValuePair, Error>>, Error>;
 
 	// Iterate elements with prefixx in key value store
 	async fn prefix_iterate<P: Into<Key> + Send>(
 		&self,
-		cf: CF,
 		prefix: P,
+		tags: TagBucket,
 	) -> Result<Vec<Result<KeyValuePair, Error>>, Error>;
 
 	// Iterate elements with prefixx in key value store
 	async fn suffix_iterate<S: Into<Key> + Send>(
 		&self,
-		cf: CF,
 		suffix: S,
+		tags: TagBucket,
 	) -> Result<Vec<Result<KeyValuePair, Error>>, Error>;
 }

--- a/db/src/storage/ds.rs
+++ b/db/src/storage/ds.rs
@@ -112,7 +112,7 @@ impl Datastore {
 mod test {
 	use crate::{
 		constant::{ColumnFamily, COLUMN_FAMILIES},
-		SimpleTransaction,
+		tag, SimpleTransaction,
 	};
 
 	use super::Datastore;
@@ -121,9 +121,6 @@ mod test {
 	async fn should_create() {
 		let db = Datastore::new("redb:../temp/v1.redb");
 		assert!(db.transaction(false).await.is_ok());
-
-		// Seeding database
-		let cf = None;
 
 		let key1 = i32::to_be_bytes(2001);
 		let key2 = "new key new data hehe";
@@ -134,9 +131,9 @@ mod test {
 		let val3 = "this is a new value";
 
 		let mut tx = db.transaction(true).await.unwrap();
-		tx.set(cf.clone(), key1, val1).await.unwrap();
-		tx.set(cf.clone(), key2, val2).await.unwrap();
-		tx.set(cf.clone(), key3, val3).await.unwrap();
+		tx.set(key1, val1, tag!()).await.unwrap();
+		tx.set(key2, val2, tag!()).await.unwrap();
+		tx.set(key3, val3, tag!()).await.unwrap();
 		tx.commit().await.unwrap();
 	}
 
@@ -147,8 +144,6 @@ mod test {
 
 		// Seeding database
 		let cf_name = COLUMN_FAMILIES.get(&ColumnFamily::TestSuite).unwrap();
-		let cf = Some(cf_name.to_string().into());
-
 		let key1 = i32::to_be_bytes(2100);
 		let key2 = "cf => hello world";
 		let key3 = "cf => this is a key";
@@ -158,9 +153,10 @@ mod test {
 		let val3 = "cf => this is a new value";
 
 		let mut tx = db.transaction(true).await.unwrap();
-		tx.set(cf.clone(), key1, val1).await.unwrap();
-		tx.set(cf.clone(), key2, val2).await.unwrap();
-		tx.set(cf.clone(), key3, val3).await.unwrap();
+		let tags = tag!("column_family" => cf_name.clone());
+		tx.set(key1, val1, tags.clone()).await.unwrap();
+		tx.set(key2, val2, tags.clone()).await.unwrap();
+		tx.set(key3, val3, tags.clone()).await.unwrap();
 		tx.commit().await.unwrap();
 	}
 }

--- a/db/src/storage/kvs/mod.rs
+++ b/db/src/storage/kvs/mod.rs
@@ -3,8 +3,6 @@ mod redb;
 #[cfg(feature = "kv-rocksdb")]
 mod rocksdb;
 
-pub const LOG: &str = "edma::kvs";
-
 #[cfg(feature = "kv-redb")]
 pub use self::redb::*;
 #[cfg(feature = "kv-rocksdb")]

--- a/db/src/storage/tx.rs
+++ b/db/src/storage/tx.rs
@@ -1,8 +1,9 @@
+use crate::TagBucket;
 use async_trait::async_trait;
 
 use crate::{
 	interface::{Key, Val},
-	Error, SimpleTransaction, CF,
+	Error, SimpleTransaction,
 };
 
 #[cfg(feature = "kv-redb")]

--- a/db/src/tests/adapter_test.rs
+++ b/db/src/tests/adapter_test.rs
@@ -2,30 +2,30 @@ use std::str::from_utf8;
 
 use crate::{
 	constant::{ColumnFamily, COLUMN_FAMILIES},
-	DatastoreAdapter, SimpleTransaction,
+	tag, DatastoreAdapter, SimpleTransaction,
 };
 
 pub async fn should_set_key(adapter: impl DatastoreAdapter) {
 	let adapter = adapter.spawn();
 	let cf_name = COLUMN_FAMILIES.get(&ColumnFamily::TestSuite).unwrap();
-	let cf = Some(cf_name.to_string().into());
 	let mut tx = adapter.transaction(true).await.unwrap();
+	let tags = tag!("column_family" => cf_name.clone());
 
 	let key = "mock key";
 	let val = "mock value";
 
-	tx.set(cf.clone(), key, val).await.unwrap();
-	assert!(tx.exi(cf.clone(), key).await.unwrap());
-	let res = tx.get(cf.clone(), key).await.unwrap();
+	tx.set(key, val, tags.clone()).await.unwrap();
+	assert!(tx.exi(key, tags.clone()).await.unwrap());
+	let res = tx.get(key, tags.clone()).await.unwrap();
 	match res {
 		Some(v) => assert_eq!(val, from_utf8(&v).unwrap()),
 		None => panic!("Wrong value"),
 	}
 
 	let new_val = "mock value 2";
-	tx.set(cf.clone(), key, new_val).await.unwrap();
-	assert!(tx.exi(cf.clone(), key).await.unwrap());
-	let res = tx.get(cf.clone(), key).await.unwrap();
+	tx.set(key, new_val, tags.clone()).await.unwrap();
+	assert!(tx.exi(key, tags.clone()).await.unwrap());
+	let res = tx.get(key, tags.clone()).await.unwrap();
 	match res {
 		Some(v) => assert_eq!(new_val, from_utf8(&v).unwrap()),
 		None => panic!("Wrong value"),
@@ -34,34 +34,34 @@ pub async fn should_set_key(adapter: impl DatastoreAdapter) {
 
 pub async fn should_delete_key(adapter: impl DatastoreAdapter) {
 	let adapter = adapter.spawn();
-	let cf = Some("test_suite:v1".into());
+	let tags = tag!("column_family" => "test_suite:v1".to_string());
 	let mut tx = adapter.transaction(true).await.unwrap();
 
 	let key = "mock key";
 	let val = "mock value";
 
-	tx.set(cf.clone(), key, val).await.unwrap();
-	assert!(tx.exi(cf.clone(), key).await.unwrap());
-	tx.del(cf.clone(), key).await.unwrap();
-	let res = tx.get(cf.clone(), key).await.unwrap();
+	tx.set(key, val, tags.clone()).await.unwrap();
+	assert!(tx.exi(key, tags.clone()).await.unwrap());
+	tx.del(key, tags.clone()).await.unwrap();
+	let res = tx.get(key, tags.clone()).await.unwrap();
 	assert_eq!(res, None);
 }
 
 pub async fn should_put_key(adapter: impl DatastoreAdapter) {
 	let adapter = adapter.spawn();
-	let cf = Some("test_suite:v1".into());
+	let tags = tag!("column_family" => "test_suite:v1".to_string());
 	let mut tx = adapter.transaction(true).await.unwrap();
 
 	let key = "mock key";
 	let val = "mock value";
 
-	tx.put(cf.clone(), key, val).await.unwrap();
-	assert!(tx.exi(cf.clone(), key).await.unwrap());
-	let res = tx.get(cf.clone(), key).await.unwrap();
+	tx.put(key, val, tags.clone()).await.unwrap();
+	assert!(tx.exi(key, tags.clone()).await.unwrap());
+	let res = tx.get(key, tags.clone()).await.unwrap();
 	match res {
 		Some(v) => assert_eq!(val, from_utf8(&v).unwrap()),
 		None => panic!("Wrong value"),
 	}
 
-	assert!(tx.put(cf.clone(), key, val).await.is_err());
+	assert!(tx.put(key, val, tags.clone()).await.is_err());
 }

--- a/gui/src/components/database/container.rs
+++ b/gui/src/components/database/container.rs
@@ -65,14 +65,13 @@ impl<'a> DatabaseTabComponent<'a> {
 
 	async fn handle_command_event(&mut self) {
 		let commands = self.command.commands.to_vec();
-		let mut cf_handle = None;
+		let cf_handle = None;
 		let (name, path, _) = self.get_database_info();
 		for command in commands {
 			match command.token.as_str() {
 				// COLUMN is specified for RocksDB, Redb should be TABLE
 				"COLUMN" => {
-					let cf = Some(&command.value);
-					cf_handle = Some(cf.unwrap().as_bytes().to_vec());
+					let cf_handle = Some(command.value);
 					self.editor.scan_database(cf_handle.clone(), &name, &path).await;
 				}
 				// PREFIX and SUFFIX scan only support key traversal not value traversal


### PR DESCRIPTION
## What is Tag Bucket? 
Tag bucket stores the configuration passed into the action handler. Therefore, more databases can be supported dynamically. Opens a chance for SQL storage integration.

- Current tag allowed are: `column_family` which for databases with column families design. There can be tags like `table` for SQL table.

```rs
type TagKey = &'static str;
type TagValue = String;
type TagBucketInner = HashMap<TagKey, TagValue>;

#[derive(Clone, Default)]
pub struct TagBucket(TagBucketInner);

impl TagBucket {
	pub fn new(map: TagBucketInner) -> TagBucket {
		TagBucket(map)
	}

	pub fn get(&self, key: TagKey) -> Option<TagValue> {
		self.0.get(key).cloned()
	}

	pub fn unchecked_get(&self, key: TagKey) -> TagValue {
		self.0.get(key).unwrap().clone()
	}

	pub fn get_bytes(&self, key: TagKey) -> Option<Vec<u8>> {
		let wrapped_value = self.0.get(key).cloned();
		if let Some(v) = wrapped_value {
			return Some(v.as_bytes().to_vec());
		}
		None
	}
}

```