### PR TITLE
Improve initial setup and error messages

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -1,0 +1,39 @@
+{
+  "databases": [
+    {
+      "name": "rocksdb",
+      "path": "../temp/cf"
+    },
+    {
+      "name": "redb",
+      "path": "../temp/redb"
+    },
+    {
+      "name": "sled",
+      "path": "../temp"
+    },
+    {
+      "name": "sled",
+      "path": "../temp/cf"
+    }
+  ],
+  "templates": [
+    {
+      "name": "Custom layout",
+      "layouts": [
+        {
+          "name": "name",
+          "from": 0,
+          "to": 5,
+          "variant": "String"
+        },
+        {
+          "name": "id",
+          "from": 5,
+          "to": 10,
+          "variant": "Int64"
+        }
+      ]
+    }
+  ]
+}

--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -16,7 +16,7 @@ pub struct DatabaseConfig {
 #[derive(StructOpt, Debug)]
 pub struct CliConfig {
 	/// Set the config file)
-	#[structopt(long, short, global = true, default_value="./config-example.json")]
+	#[structopt(long, short, global = true, default_value="./edma.json")]
 	config_path: std::path::PathBuf,
 	/// Create a new example config file
 	#[structopt(long, global = true)]

--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, path::{Path, PathBuf}};
 
 use serde_json::Value;
 use structopt::StructOpt;
@@ -15,9 +15,12 @@ pub struct DatabaseConfig {
 
 #[derive(StructOpt, Debug)]
 pub struct CliConfig {
-	/// Set the config file
-	#[structopt(long, short, global = true)]
-	config_path: Option<std::path::PathBuf>,
+	/// Set the config file)
+	#[structopt(long, short, global = true, default_value="./config-example.json")]
+	config_path: std::path::PathBuf,
+	/// Create a new example config file
+	#[structopt(long, global = true)]
+	create_config: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -58,14 +61,9 @@ fn build_template(name: &str, variant: LayoutVariant) -> LayoutTemplate {
 
 impl Config {
 	pub fn new(config: &CliConfig) -> Self {
-		let binding = Path::new("./config-example.json").to_path_buf();
-		let path = match &config.config_path {
-			Some(c) => c,
-			None => &binding,
-		};
 		Config {
 			databases: Default::default(),
-			path: get_absolute_path_buf(path.to_path_buf()),
+			path: get_absolute_path_buf(config.config_path.to_path_buf()),
 			templates: Default::default(),
 			key_config: KeyConfig {
 				backspace: Key::Backspace,
@@ -98,9 +96,24 @@ impl Config {
 	}
 }
 
+fn create_config_example(path: &PathBuf) {
+	let config_example = include_str!("../config-example.json");
+	if !path.exists() {
+		println!("Creating config file: {}", path.to_str().unwrap());
+		fs::write(path, config_example).unwrap();
+	} else {
+		panic!("Config file already exists: {}", path.to_str().unwrap());
+	}
+}
+
 pub fn load_config(cli: &CliConfig) -> Config {
 	let mut config = Config::new(cli);
-	let data = fs::read_to_string(config.clone().path).expect("Unable to read file");
+	if cli.create_config {
+		create_config_example(&cli.config_path);
+	}
+	let Ok(data) = fs::read_to_string(&config.path) else {
+		panic!("Unable to read config file: {}. Run with `--create-config` to create an example config file", config.path)
+	};
 	let res: serde_json::Value = serde_json::from_str(&data).expect("Unable to parse");
 
 	if let Some(d) = res.get("databases") {


### PR DESCRIPTION
- When the user doesn't have a config in its selected path, give a helpful error message
- Create a new example config using the CLI flag `--create-config`
- Use StructOpts `default_value` feature
- Change default path to `edma.json` (seems a bit easier to understand than `default-config.json` in a non-edma dir)